### PR TITLE
名称の変更など

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Kasane-Logic"
+version = "0.0.1"
+dependencies = [
+ "criterion",
+ "schemars",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,16 +225,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "logic"
-version = "0.1.0"
-dependencies = [
- "criterion",
- "schemars",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Kasane-Logic"
-version = "0.0.1"
-dependencies = [
- "criterion",
- "schemars",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +208,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasane-logic"
+version = "0.0.1"
+dependencies = [
+ "criterion",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
-name = "logic"
-version = "0.1.0"
+name = "Kasane-Logic"
+version = "0.0.1"
 edition = "2024"
+license = "MIT"
+
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Kasane-Logic"
+name = "kasane-logic"
 version = "0.0.1"
 edition = "2024"
 license = "MIT"

--- a/benches/id_new.rs
+++ b/benches/id_new.rs
@@ -1,5 +1,8 @@
+use Kasane_Logic::id::{
+    DimensionRange::{AfterUnLimitRange, Any, BeforeUnLimitRange, LimitRange, Single},
+    SpaceTimeId,
+};
 use criterion::{Criterion, criterion_group, criterion_main};
-use logic::id::{DimensionRange, SpaceTimeId};
 use std::hint::black_box;
 
 fn bench_spacetimeid_valid_full_range(c: &mut Criterion) {

--- a/src/id/coordinates.rs
+++ b/src/id/coordinates.rs
@@ -1,5 +1,5 @@
-use crate::id::{DimensionRange, SpaceTimeId};
 use crate::id::DimensionRange::{AfterUnLimitRange, Any, BeforeUnLimitRange, LimitRange, Single};
+use crate::id::{DimensionRange, SpaceTimeId};
 use std::f64::consts::PI;
 
 #[cfg_attr(
@@ -32,7 +32,6 @@ impl SpaceTimeId {
     /// # Returns
     /// A [`Coordinates`] struct containing the latitude, longitude, and altitude ranges
     /// as floating-point tuples `(start, end)`, representing the spatial extent.
-
     pub fn coordinates(&self) -> Coordinates {
         let n = 2_u64.pow(self.z as u32);
 

--- a/src/id/mod.rs
+++ b/src/id/mod.rs
@@ -2,8 +2,8 @@ pub mod center;
 pub mod change_scale;
 pub mod complement;
 pub mod coordinates;
+pub mod pure;
 pub mod relation;
-pub mod to_pure;
 pub mod value;
 pub mod vertex;
 

--- a/src/id/pure.rs
+++ b/src/id/pure.rs
@@ -1,10 +1,10 @@
-use crate::id::{DimensionRange, SpaceTimeId};
 use crate::id::DimensionRange::{AfterUnLimitRange, Any, BeforeUnLimitRange, LimitRange, Single};
+use crate::id::{DimensionRange, SpaceTimeId};
 
 impl SpaceTimeId {
     /// 拡張記法 (Range, Before, After, Any) をすべて展開して
     /// 各次元が Single だけの純粋な ID 群を返す
-    pub fn to_pure(&self) -> Vec<SpaceTimeId> {
+    pub fn pure(&self) -> Vec<SpaceTimeId> {
         let z = self.z();
         let i = self.i();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use Kasane_Logic::{
+use kasane_logic::{
     id::{
         self,
         DimensionRange::{AfterUnLimitRange, Any, BeforeUnLimitRange, LimitRange, Single},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use logic::{
+use Kasane_Logic::{
     id::{
         self,
         DimensionRange::{AfterUnLimitRange, Any, BeforeUnLimitRange, LimitRange, Single},
@@ -9,8 +9,6 @@ use logic::{
 
 fn main() {
     let id2 = SpaceTimeId::new(3, Any, LimitRange(1, 3), Any, 3, BeforeUnLimitRange(6)).unwrap();
-
     println!("{},", id2);
-
     println!("{},", id2.complement());
 }

--- a/src/set/to_pure.rs
+++ b/src/set/to_pure.rs
@@ -4,7 +4,7 @@ impl SpaceTimeIdSet {
     pub fn to_pure(&self) -> Vec<SpaceTimeId> {
         let mut result = vec![];
         for stid in &self.inner {
-            let stid_pure = stid.to_pure();
+            let stid_pure = stid.pure();
             for pure in stid_pure {
                 result.push(pure);
             }


### PR DESCRIPTION
- `to_pure`を`pure`に変更
- ライブラリの名前を`kasane-logic`に変更