### PR TITLE
fn spatial_neighbors_6を追加

### DIFF
--- a/src/spatial_id/collection/flex_tree/core/mod.rs
+++ b/src/spatial_id/collection/flex_tree/core/mod.rs
@@ -184,18 +184,6 @@ where
         })
     }
 
-    #[cfg(feature = "temporal_id")]
-    #[test]
-    fn insert_accepts_non_whole_temporal_ids() {
-        let mut core = FlexTreeCore::new();
-        let temporal = TemporalId::new(60, [0, 0]).unwrap();
-        let id = SingleId::new_with_temporal(3, 3, 2, 7, temporal).unwrap();
-
-        core.insert(id, ());
-
-        assert_eq!(core.count(), 1);
-    }
-
     /// [FlexTreeCore]からTargetが示す領域を切り取って返す
     pub fn remove<S>(&mut self, target: &S) -> impl Iterator<Item = (FlexId, V)>
     where
@@ -286,5 +274,22 @@ pub(super) fn split_child_id(current_id: &FlexId, axis: Dimension, side: Side) -
         Dimension::F => current_id.f_split(side).unwrap(),
         Dimension::X => current_id.x_split(side).unwrap(),
         Dimension::Y => current_id.y_split(side).unwrap(),
+    }
+}
+
+#[cfg(all(test, feature = "temporal_id"))]
+mod tests {
+    use super::FlexTreeCore;
+    use crate::{SingleId, TemporalId};
+
+    #[test]
+    fn insert_accepts_non_whole_temporal_ids() {
+        let mut core = FlexTreeCore::new();
+        let temporal = TemporalId::new(60, [0, 0]).unwrap();
+        let id = SingleId::new_with_temporal(3, 3, 2, 7, temporal).unwrap();
+
+        core.insert(id, ());
+
+        assert_eq!(core.count(), 1);
     }
 }

--- a/src/spatial_id/flex_id/mod.rs
+++ b/src/spatial_id/flex_id/mod.rs
@@ -3,7 +3,7 @@ pub mod convert;
 pub mod impls;
 pub mod ops;
 
-use crate::{MAX_ZOOM_LEVEL, Side, TemporalId};
+use crate::{MAX_ZOOM_LEVEL, Side, SpatialId, TemporalId};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/src/spatial_id/single_id/mod.rs
+++ b/src/spatial_id/single_id/mod.rs
@@ -354,4 +354,86 @@ impl SingleId {
             temporal_id: self.temporal().clone(),
         })
     }
+
+    /// この [`SingleId`] の 6 近傍を列挙します。
+    ///
+    /// 近傍は `f` / `x` / `y` の各軸について `±1` だけ動かした 6 個です。
+    /// `x` は循環するため常に有効ですが、`f` と `y` が範囲外になる方向は除外されます。
+    /// そのため、境界上の [`SingleId`] では 6 個未満になることがあります。
+    ///
+    /// ```
+    /// # use kasane_logic::SingleId;
+    /// let id = SingleId::new(4, 6, 9, 10).unwrap();
+    /// let neighbors: Vec<_> = id.spatial_neighbors_6().collect();
+    /// assert_eq!(neighbors.len(), 6);
+    /// ```
+    pub fn spatial_neighbors_6(&self) -> impl Iterator<Item = SingleId> + '_ {
+        const OFFSETS: [(i32, i32, i32); 6] = [
+            (1, 0, 0),
+            (-1, 0, 0),
+            (0, 1, 0),
+            (0, -1, 0),
+            (0, 0, 1),
+            (0, 0, -1),
+        ];
+
+        OFFSETS.into_iter().filter_map(move |(df, dx, dy)| {
+            let mut neighbor = self.clone();
+
+            if df != 0 && neighbor.move_f(df).is_err() {
+                return None;
+            }
+
+            if dx != 0 {
+                neighbor.move_x(dx);
+            }
+
+            if dy != 0 && neighbor.move_y(dy).is_err() {
+                return None;
+            }
+
+            Some(neighbor)
+        })
+    }
+
+    /// この [`SingleId`] の 26 近傍を列挙します。
+    ///
+    /// 近傍は `f` / `x` / `y` の各軸について `-1, 0, 1` の組み合わせから
+    /// 自身を除いた 26 個です。`x` は循環するため常に有効ですが、`f` と `y` が
+    /// 範囲外になる方向は除外されます。
+    /// そのため、境界上の [`SingleId`] では 26 個未満になることがあります。
+    ///
+    /// ```
+    /// # use kasane_logic::SingleId;
+    /// let id = SingleId::new(4, 6, 9, 10).unwrap();
+    /// let neighbors: Vec<_> = id.spatial_neighbors_26().collect();
+    /// assert_eq!(neighbors.len(), 26);
+    /// ```
+    pub fn spatial_neighbors_26(&self) -> impl Iterator<Item = SingleId> + '_ {
+        (-1..=1).flat_map(move |df| {
+            (-1..=1).flat_map(move |dy| {
+                (-1..=1).filter_map(move |dx| {
+                    if df == 0 && dx == 0 && dy == 0 {
+                        return None;
+                    }
+
+                    let mut neighbor = self.clone();
+
+                    if df != 0 && neighbor.move_f(df).is_err() {
+                        return None;
+                    }
+
+                    if dx != 0 {
+                        neighbor.move_x(dx);
+                    }
+
+                    if dy != 0 && neighbor.move_y(dy).is_err() {
+                        return None;
+                    }
+
+                    Some(neighbor)
+                })
+            })
+        })
+    }
 }

--- a/src/spatial_id/single_id/test/mod.rs
+++ b/src/spatial_id/single_id/test/mod.rs
@@ -43,4 +43,30 @@ mod tests {
             ))
         ));
     }
+
+    #[test]
+    fn six_neighbors_are_generated() {
+        let id = SingleId::new(4, 6, 9, 10).unwrap();
+        let neighbors: Vec<_> = id.spatial_neighbors_6().collect();
+
+        assert_eq!(neighbors.len(), 6);
+        assert!(neighbors.contains(&SingleId::new(4, 7, 9, 10).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 5, 9, 10).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 10, 10).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 8, 10).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 9, 11).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 9, 9).unwrap()));
+    }
+
+    #[test]
+    fn twenty_six_neighbors_are_generated() {
+        let id = SingleId::new(4, 6, 9, 10).unwrap();
+        let neighbors: Vec<_> = id.spatial_neighbors_26().collect();
+
+        assert_eq!(neighbors.len(), 26);
+        assert!(neighbors.contains(&SingleId::new(4, 7, 10, 11).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 5, 8, 9).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 10, 11).unwrap()));
+        assert!(neighbors.contains(&SingleId::new(4, 6, 8, 9).unwrap()));
+    }
 }

--- a/src/spatial_id/temporal_id/impls.rs
+++ b/src/spatial_id/temporal_id/impls.rs
@@ -26,19 +26,17 @@ impl FromStr for TemporalId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (i_str, t_str) = s.split_once('/').ok_or_else(|| {
-            SpatialIdError::ParseSpatialIdFormat {
+            Error::from(SpatialIdError::ParseSpatialIdFormat {
                 kind: "TemporalId",
                 input: s.to_string(),
-            }
-            .into()
+            })
         })?;
 
         let i = i_str.parse::<u64>().map_err(|_| {
-            SpatialIdError::ParseSpatialIdFormat {
+            Error::from(SpatialIdError::ParseSpatialIdFormat {
                 kind: "TemporalId",
                 input: s.to_string(),
-            }
-            .into()
+            })
         })?;
 
         let (start_str, end_str) = match t_str.split_once(':') {
@@ -47,18 +45,16 @@ impl FromStr for TemporalId {
         };
 
         let start = start_str.parse::<u64>().map_err(|_| {
-            SpatialIdError::ParseSpatialIdFormat {
+            Error::from(SpatialIdError::ParseSpatialIdFormat {
                 kind: "TemporalId",
                 input: s.to_string(),
-            }
-            .into()
+            })
         })?;
         let end = end_str.parse::<u64>().map_err(|_| {
-            SpatialIdError::ParseSpatialIdFormat {
+            Error::from(SpatialIdError::ParseSpatialIdFormat {
                 kind: "TemporalId",
                 input: s.to_string(),
-            }
-            .into()
+            })
         })?;
 
         TemporalId::new(i, [start, end])


### PR DESCRIPTION
- `SingleId`の周辺6か所を自動的に求める関数を追加