### PR TITLE
`iter_*`と`into_*`の役割が被っていたため整理

### DIFF
--- a/docs/geometry-relation.md
+++ b/docs/geometry-relation.md
@@ -51,15 +51,13 @@ Solid -->|"Solid → Polygon×N"| Polygon
 
 分解可能な型は、次のトレイトを直接実装する。
 
-- `IntoCoordinates`
-- `IntoLines`
-- `IntoTriangles`
-- `IntoPolygons`
+- `IterCoordinates`
+- `IterLines`
+- `IterTriangles`
+- `IterPolygons`
 
-各トレイトは以下の2つのメソッドを持つ。
+各トレイトは以下の1つのメソッドを持つ。
 
-- `into_*()`
-  - 所有権を受け取り、対応する型のイテレーターを返す。
 - `iter_*()`
   - 参照を受け取り、対応する型のイテレーターを返す。
 

--- a/src/geometry/shapes/cylinder/geometry_relation.rs
+++ b/src/geometry/shapes/cylinder/geometry_relation.rs
@@ -1,22 +1,19 @@
 use crate::{
-    Coordinate, Cylinder, Ecef, IntoCoordinates, IntoLines, IntoPolygons, IntoSolids,
-    IntoTriangles, Line, Polygon, Solid, Triangle, Vec3,
+    Coordinate, Cylinder, Ecef, IterCoordinates, IterLines, IterPolygons, IterSolids,
+    IterTriangles, Line, Polygon, Solid, Triangle, Vec3,
 };
 use std::f64::consts::PI;
 
-impl IntoSolids for Cylinder {
-    fn into_solids(self) -> impl Iterator<Item = Solid> {
-        let polygons = self.into_polygons().collect();
+impl IterSolids for Cylinder {
+    fn iter_solids(&self) -> impl Iterator<Item = Solid> {
+        let polygons = self.iter_polygons().collect();
         let solid = Solid::new(polygons, 1e-10).unwrap();
         std::iter::once(solid)
     }
-    fn iter_solids(&self) -> impl Iterator<Item = Solid> {
-        self.clone().into_solids()
-    }
 }
 
-impl IntoPolygons for Cylinder {
-    fn into_polygons(self) -> impl Iterator<Item = Polygon> {
+impl IterPolygons for Cylinder {
+    fn iter_polygons(&self) -> impl Iterator<Item = Polygon> {
         let vecs: [Vec3; 2] = [self.start.into(), self.end.into()];
         let vec_n = vecs[1] - vecs[0];
         let basis = vec_n
@@ -66,36 +63,34 @@ impl IntoPolygons for Cylinder {
 
         raw_surfaces.into_iter()
     }
-    fn iter_polygons(&self) -> impl Iterator<Item = Polygon> {
-        self.clone().into_polygons()
-    }
 }
 
-impl IntoTriangles for Cylinder {
-    fn into_triangles(self) -> impl Iterator<Item = Triangle> {
-        self.into_solids().flat_map(|s| s.into_triangles())
-    }
+impl IterTriangles for Cylinder {
     fn iter_triangles(&self) -> impl Iterator<Item = Triangle> {
-        self.clone().into_solids().flat_map(|s| s.into_triangles())
+        let triangles: Vec<Triangle> = self
+            .iter_solids()
+            .flat_map(|solid| solid.iter_triangles().collect::<Vec<_>>())
+            .collect();
+        triangles.into_iter()
     }
 }
 
-impl IntoLines for Cylinder {
-    fn into_lines(self) -> impl Iterator<Item = Line> {
-        self.into_solids().flat_map(|s| s.into_lines())
-    }
+impl IterLines for Cylinder {
     fn iter_lines(&self) -> impl Iterator<Item = Line> {
-        self.clone().into_solids().flat_map(|s| s.into_lines())
+        let lines: Vec<Line> = self
+            .iter_solids()
+            .flat_map(|solid| solid.iter_lines().collect::<Vec<_>>())
+            .collect();
+        lines.into_iter()
     }
 }
 
-impl IntoCoordinates for Cylinder {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate> {
-        self.into_solids().flat_map(|s| s.into_coordinates())
-    }
+impl IterCoordinates for Cylinder {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate> {
-        self.clone()
-            .into_solids()
-            .flat_map(|s| s.into_coordinates())
+        let coordinates: Vec<Coordinate> = self
+            .iter_solids()
+            .flat_map(|solid| solid.iter_coordinates().collect::<Vec<_>>())
+            .collect();
+        coordinates.into_iter()
     }
 }

--- a/src/geometry/shapes/cylinder/impls.rs
+++ b/src/geometry/shapes/cylinder/impls.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Coordinate, CoverRangeIds, CoverSingleIds, Cylinder, Error, IntoSolids, RangeId, Shape,
+    Coordinate, CoverRangeIds, CoverSingleIds, Cylinder, Error, IterSolids, RangeId, Shape,
     SingleId,
 };
 

--- a/src/geometry/shapes/line/geometry_relation.rs
+++ b/src/geometry/shapes/line/geometry_relation.rs
@@ -1,10 +1,6 @@
-use crate::{Coordinate, IntoCoordinates, Line};
+use crate::{Coordinate, IterCoordinates, Line};
 
-impl IntoCoordinates for Line {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate> {
-        self.points.into_iter()
-    }
-
+impl IterCoordinates for Line {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate> {
         self.points.into_iter()
     }

--- a/src/geometry/shapes/polygon/geometry_relation.rs
+++ b/src/geometry/shapes/polygon/geometry_relation.rs
@@ -1,36 +1,23 @@
-use crate::{Coordinate, Ecef, IntoCoordinates, IntoLines, IntoTriangles, Line, Polygon, Triangle};
+use crate::{Coordinate, Ecef, IterCoordinates, IterLines, IterTriangles, Line, Polygon, Triangle};
 
-impl IntoCoordinates for Polygon {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate> {
-        self.vertices.into_iter()
-    }
-
+impl IterCoordinates for Polygon {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate> {
         self.vertices.clone().into_iter()
     }
 }
 
-impl IntoLines for Polygon {
-    fn into_lines(self) -> impl Iterator<Item = Line> {
-        let triangles: Vec<Triangle> = self.into_triangles().collect();
-        triangles
-            .into_iter()
-            .flat_map(|triangle| triangle.into_lines())
-    }
-
+impl IterLines for Polygon {
     fn iter_lines(&self) -> impl Iterator<Item = Line> {
         let triangles: Vec<Triangle> = self.iter_triangles().collect();
-        triangles
+        let lines: Vec<Line> = triangles
             .into_iter()
-            .flat_map(|triangle| triangle.into_lines())
+            .flat_map(|triangle| triangle.iter_lines().collect::<Vec<_>>())
+            .collect();
+        lines.into_iter()
     }
 }
 
-impl IntoTriangles for Polygon {
-    fn into_triangles(self) -> impl Iterator<Item = Triangle> {
-        self.iter_triangles().collect::<Vec<_>>().into_iter()
-    }
-
+impl IterTriangles for Polygon {
     fn iter_triangles(&self) -> impl Iterator<Item = Triangle> {
         let n = self.vertices.len();
         if n < 3 {

--- a/src/geometry/shapes/polygon/impls.rs
+++ b/src/geometry/shapes/polygon/impls.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    Coordinate, IntoTriangles, Polygon, Shape, SingleId, geometry::traits::CoverSingleIds,
+    Coordinate, IterTriangles, Polygon, Shape, SingleId, geometry::traits::CoverSingleIds,
 };
 
 impl Shape for Polygon {

--- a/src/geometry/shapes/solid/geometry_relation.rs
+++ b/src/geometry/shapes/solid/geometry_relation.rs
@@ -1,15 +1,9 @@
 use crate::{
-    Coordinate, IntoCoordinates, IntoLines, IntoPolygons, IntoTriangles, Line, Polygon, Solid,
+    Coordinate, IterCoordinates, IterLines, IterPolygons, IterTriangles, Line, Polygon, Solid,
     Triangle,
 };
 
-impl IntoCoordinates for Solid {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate> {
-        self.polygons
-            .into_iter()
-            .flat_map(|polygon| polygon.into_coordinates())
-    }
-
+impl IterCoordinates for Solid {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate> {
         self.polygons
             .iter()
@@ -17,40 +11,30 @@ impl IntoCoordinates for Solid {
     }
 }
 
-impl IntoLines for Solid {
-    fn into_lines(self) -> impl Iterator<Item = Line> {
-        self.polygons
-            .into_iter()
-            .flat_map(|polygon| polygon.into_lines())
-    }
-
+impl IterLines for Solid {
     fn iter_lines(&self) -> impl Iterator<Item = Line> {
-        self.polygons
+        let lines: Vec<Line> = self
+            .polygons
             .iter()
-            .flat_map(|polygon| polygon.iter_lines())
+            .flat_map(|polygon| polygon.iter_lines().collect::<Vec<_>>())
+            .collect();
+        lines.into_iter()
     }
 }
 
-impl IntoTriangles for Solid {
-    fn into_triangles(self) -> impl Iterator<Item = Triangle> {
-        self.polygons
-            .into_iter()
-            .flat_map(|polygon| polygon.into_triangles())
-    }
-
+impl IterTriangles for Solid {
     fn iter_triangles(&self) -> impl Iterator<Item = Triangle> {
-        self.polygons
+        let triangles: Vec<Triangle> = self
+            .polygons
             .iter()
-            .flat_map(|polygon| polygon.iter_triangles())
+            .flat_map(|polygon| polygon.iter_triangles().collect::<Vec<_>>())
+            .collect();
+        triangles.into_iter()
     }
 }
 
-impl IntoPolygons for Solid {
-    fn into_polygons(self) -> impl Iterator<Item = Polygon> {
-        self.polygons.into_iter()
-    }
-
+impl IterPolygons for Solid {
     fn iter_polygons(&self) -> impl Iterator<Item = Polygon> {
-        self.polygons.clone().into_iter()
+        self.polygons.iter().cloned()
     }
 }

--- a/src/geometry/shapes/solid/impls.rs
+++ b/src/geometry/shapes/solid/impls.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use crate::{
-    Coordinate, Error, IntoCoordinates, IntoSingleIds, RangeId, Shape, SingleId, Solid, SpatialId,
+    Coordinate, Error, IterCoordinates, IntoSingleIds, RangeId, Shape, SingleId, Solid, SpatialId,
     geometry::traits::{CoverRangeIds, CoverSingleIds},
 };
 

--- a/src/geometry/shapes/solid/mod.rs
+++ b/src/geometry/shapes/solid/mod.rs
@@ -1,5 +1,5 @@
 use crate::geometry::shapes::polygon::Polygon;
-use crate::{CoverSingleIds as _, Ecef, Error, GeometryError, IntoTriangles, SingleId, Triangle};
+use crate::{CoverSingleIds as _, Ecef, Error, GeometryError, IterTriangles, SingleId, Triangle};
 use std::collections::{HashMap, HashSet};
 
 pub mod geometry_relation;

--- a/src/geometry/shapes/traits.rs
+++ b/src/geometry/shapes/traits.rs
@@ -13,7 +13,7 @@ pub trait Shape {
 ///
 /// # Examples
 /// ```
-/// use kasane_logic::{Coordinate, IntoCoordinates, Line};
+/// use kasane_logic::{Coordinate, IterCoordinates, Line};
 ///
 /// let p0 = Coordinate::new(35.0, 139.0, 10.0).unwrap();
 /// let p1 = Coordinate::new(35.0001, 139.0001, 11.0).unwrap();
@@ -22,8 +22,7 @@ pub trait Shape {
 /// let coords: Vec<Coordinate> = line.iter_coordinates().collect();
 /// assert_eq!(coords.len(), 2);
 /// ```
-pub trait IntoCoordinates {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate>;
+pub trait IterCoordinates {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate>;
 }
 
@@ -33,18 +32,17 @@ pub trait IntoCoordinates {
 ///
 /// # Examples
 /// ```
-/// use kasane_logic::{Coordinate, IntoLines, Line, Triangle};
+/// use kasane_logic::{Coordinate, IterLines, Line, Triangle};
 ///
 /// let p0 = Coordinate::new(35.0, 139.0, 10.0).unwrap();
 /// let p1 = Coordinate::new(35.0002, 139.0, 10.0).unwrap();
 /// let p2 = Coordinate::new(35.0, 139.0002, 10.0).unwrap();
 /// let tri = Triangle::new([p0, p1, p2]);
 ///
-/// let lines: Vec<Line> = tri.into_lines().collect();
+/// let lines: Vec<Line> = tri.iter_lines().collect();
 /// assert_eq!(lines.len(), 3);
 /// ```
-pub trait IntoLines {
-    fn into_lines(self) -> impl Iterator<Item = Line>;
+pub trait IterLines {
     fn iter_lines(&self) -> impl Iterator<Item = Line>;
 }
 
@@ -54,7 +52,7 @@ pub trait IntoLines {
 ///
 /// # Examples
 /// ```
-/// use kasane_logic::{Coordinate, IntoTriangles, Polygon, Triangle};
+/// use kasane_logic::{Coordinate, IterTriangles, Polygon, Triangle};
 ///
 /// let p0 = Coordinate::new(35.0, 139.0, 10.0).unwrap();
 /// let p1 = Coordinate::new(35.0003, 139.0, 10.0).unwrap();
@@ -65,8 +63,7 @@ pub trait IntoLines {
 /// let triangles: Vec<Triangle> = polygon.iter_triangles().collect();
 /// assert_eq!(triangles.len(), 2);
 /// ```
-pub trait IntoTriangles {
-    fn into_triangles(self) -> impl Iterator<Item = Triangle>;
+pub trait IterTriangles {
     fn iter_triangles(&self) -> impl Iterator<Item = Triangle>;
 }
 
@@ -76,7 +73,7 @@ pub trait IntoTriangles {
 ///
 /// # Examples
 /// ```
-/// use kasane_logic::{Coordinate, IntoPolygons, Polygon, Solid};
+/// use kasane_logic::{Coordinate, IterPolygons, Polygon, Solid};
 ///
 /// let p0 = Coordinate::new(35.0, 139.0, 10.0).unwrap();
 /// let p1 = Coordinate::new(35.0003, 139.0, 10.0).unwrap();
@@ -91,15 +88,13 @@ pub trait IntoTriangles {
 /// ];
 ///
 /// let solid = Solid::new(surfaces, 0.01).unwrap();
-/// let polygons: Vec<Polygon> = solid.into_polygons().collect();
+/// let polygons: Vec<Polygon> = solid.iter_polygons().collect();
 /// assert_eq!(polygons.len(), 4);
 /// ```
-pub trait IntoPolygons {
-    fn into_polygons(self) -> impl Iterator<Item = Polygon>;
+pub trait IterPolygons {
     fn iter_polygons(&self) -> impl Iterator<Item = Polygon>;
 }
 
-pub trait IntoSolids {
-    fn into_solids(self) -> impl Iterator<Item = Solid>;
+pub trait IterSolids {
     fn iter_solids(&self) -> impl Iterator<Item = Solid>;
 }

--- a/src/geometry/shapes/triangle/geometry_relation.rs
+++ b/src/geometry/shapes/triangle/geometry_relation.rs
@@ -1,25 +1,12 @@
-use crate::{Coordinate, IntoCoordinates, IntoLines, Line, Triangle};
+use crate::{Coordinate, IterCoordinates, IterLines, Line, Triangle};
 
-impl IntoCoordinates for Triangle {
-    fn into_coordinates(self) -> impl Iterator<Item = Coordinate> {
-        self.points.into_iter()
-    }
-
+impl IterCoordinates for Triangle {
     fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate> {
         self.points.into_iter()
     }
 }
 
-impl IntoLines for Triangle {
-    fn into_lines(self) -> impl Iterator<Item = Line> {
-        [
-            Line::new([self.points[0], self.points[1]]),
-            Line::new([self.points[1], self.points[2]]),
-            Line::new([self.points[2], self.points[0]]),
-        ]
-        .into_iter()
-    }
-
+impl IterLines for Triangle {
     fn iter_lines(&self) -> impl Iterator<Item = Line> {
         [
             Line::new([self.points[0], self.points[1]]),

--- a/src/geometry/shapes/triangle/impls.rs
+++ b/src/geometry/shapes/triangle/impls.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::{
-    Coordinate, Error, IntoCoordinates, Shape, SingleId, Triangle,
+    Coordinate, Error, IterCoordinates, Shape, SingleId, Triangle,
     geometry::{shapes::triangle::coordinate_to_matrix, traits::CoverSingleIds},
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use geometry::shapes::triangle::Triangle;
 // geometry: traits
 #[doc(inline)]
 pub use geometry::shapes::traits::{
-    IntoCoordinates, IntoLines, IntoPolygons, IntoSolids, IntoTriangles, Shape,
+    IterCoordinates, IterLines, IterPolygons, IterSolids, IterTriangles, Shape,
 };
 #[doc(inline)]
 pub use geometry::traits::{CoverRangeIds, CoverSingleIds};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 use kasane_logic::Coordinate;
 use kasane_logic::CoverSingleIds;
 use kasane_logic::Cylinder;
-use kasane_logic::IntoSolids;
+use kasane_logic::IterSolids;
 use std::io::Write;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tokyo = Coordinate::new(35.681382, 139.76608399999998, 0.0)?;
     let tokyo_dash = Coordinate::new(35.6813, 139.764, 500.0)?;
     let c = Cylinder::new(tokyo, tokyo_dash, 6.0)?;
-    let s = c.into_solids().next().unwrap();
+    let s = c.iter_solids().next().unwrap();
     let ids = s.cover_single_ids(25).unwrap();
 
     let mut file = std::fs::File::create("output.txt")?;


### PR DESCRIPTION
# 問題点
`geometry` の分解 API が `into_*` と `iter_*` で二重化していて、ほとんど違いがない。下記のように、実質的に帰ってくるものは同じだし、実質的に行うことはほとんど演算なので、所有権を消費する`into_*`が有利な場面は少ない。

```rs
pub trait IntoCoordinates {
    fn into_coordinates(self) -> impl Iterator<Item = Coordinate>;
    fn iter_coordinates(&self) -> impl Iterator<Item = Coordinate>;
}
```

# 解決策
`iter_*` ベースに一本化し、trait 名も `IterCoordinates` / `IterLines` / `IterTriangles` / `IterPolygons` / `IterSolids` に統一する。

# 実施内容
- `into_*` 系のメソッドを削除し、`iter_*` のみを残した。
- trait 名を `Into*` から `Iter*` に変更した。
- `line` / `triangle` / `polygon` / `solid` / `cylinder` の実装を更新。
- main.rs の呼び出しを `iter_solids()` ベースに変更。
- geometry-relation.md と traits.rs の説明・例示を更新。