### PR TITLE
SingleIdの兄弟を求める関数を追加

### DIFF
--- a/src/spatial_id/single_id/mod.rs
+++ b/src/spatial_id/single_id/mod.rs
@@ -357,6 +357,114 @@ impl SingleId {
         })
     }
 
+    /// この [`SingleId`] と同じ親を共有する兄弟 [`SingleId`] を 7 個返す。
+    ///
+    /// 返される 7 個と自分自身を合わせると、1つ上のズームレベルにある親 [`SingleId`] を構成する。
+    /// `z = 0` の場合は親を持たないため `None` を返す。
+    ///
+    /// # 動作例
+    ///
+    /// 兄弟の列挙:
+    /// ```
+    /// # use kasane_logic::SingleId;
+    /// let id = SingleId::new(3, 3, 2, 7).unwrap();
+    /// let siblings = id.spatial_siblings().unwrap();
+    ///
+    /// assert_eq!(siblings.len(), 7);
+    /// assert!(siblings.iter().all(|s| s.spatial_parent_at_zoom(2).unwrap() == id.spatial_parent_at_zoom(2).unwrap()));
+    /// assert!(!siblings.contains(&id));
+    /// ```
+    ///
+    /// 最上位の ID の場合:
+    /// ```
+    /// # use kasane_logic::SingleId;
+    /// let id = SingleId::new(0, 0, 0, 0).unwrap();
+    /// assert!(id.spatial_siblings().is_none());
+    /// ```
+    pub fn spatial_siblings(&self) -> Option<[SingleId; 7]> {
+        if self.z == 0 {
+            return None;
+        }
+
+        let parent_z = self.z - 1;
+        let parent = self.spatial_parent_at_zoom(parent_z).ok()?;
+        let next_z = self.z;
+        let f_start = parent.f() * 2;
+        let x_start = parent.x() * 2;
+        let y_start = parent.y() * 2;
+
+        let candidates = [
+            SingleId {
+                z: next_z,
+                f: f_start,
+                x: x_start,
+                y: y_start,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start,
+                x: x_start,
+                y: y_start + 1,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start,
+                x: x_start + 1,
+                y: y_start,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start,
+                x: x_start + 1,
+                y: y_start + 1,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start + 1,
+                x: x_start,
+                y: y_start,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start + 1,
+                x: x_start,
+                y: y_start + 1,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start + 1,
+                x: x_start + 1,
+                y: y_start,
+                temporal_id: parent.temporal().clone(),
+            },
+            SingleId {
+                z: next_z,
+                f: f_start + 1,
+                x: x_start + 1,
+                y: y_start + 1,
+                temporal_id: parent.temporal().clone(),
+            },
+        ];
+
+        let mut siblings: [Option<SingleId>; 7] = [None, None, None, None, None, None, None];
+        let mut index = 0;
+
+        for child in candidates {
+            if child != *self {
+                siblings[index] = Some(child);
+                index += 1;
+            }
+        }
+
+        Some(siblings.map(|child| child.expect("sibling set should contain exactly 7 items")))
+    }
+
     /// この [`SingleId`] の全ての親を、直近の親から順に列挙する。
     ///
     /// 返す順序は `z - 1`, `z - 2`, ..., `0` であり、元の [`SingleId`] 自身は含まない。

--- a/src/spatial_id/single_id/mod.rs
+++ b/src/spatial_id/single_id/mod.rs
@@ -462,7 +462,18 @@ impl SingleId {
             }
         }
 
-        Some(siblings.map(|child| child.expect("sibling set should contain exactly 7 items")))
+        debug_assert_eq!(index, 7, "sibling set should contain exactly 7 items");
+        if index != 7 {
+            return None;
+        }
+
+        let [a, b, c, d, e, f, g] = siblings;
+        match (a, b, c, d, e, f, g) {
+            (Some(a), Some(b), Some(c), Some(d), Some(e), Some(f), Some(g)) => {
+                Some([a, b, c, d, e, f, g])
+            }
+            _ => None,
+        }
     }
 
     /// この [`SingleId`] の全ての親を、直近の親から順に列挙する。

--- a/src/spatial_id/single_id/mod.rs
+++ b/src/spatial_id/single_id/mod.rs
@@ -399,56 +399,56 @@ impl SingleId {
                 f: f_start,
                 x: x_start,
                 y: y_start,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start,
                 x: x_start,
                 y: y_start + 1,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start,
                 x: x_start + 1,
                 y: y_start,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start,
                 x: x_start + 1,
                 y: y_start + 1,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start + 1,
                 x: x_start,
                 y: y_start,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start + 1,
                 x: x_start,
                 y: y_start + 1,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start + 1,
                 x: x_start + 1,
                 y: y_start,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
             SingleId {
                 z: next_z,
                 f: f_start + 1,
                 x: x_start + 1,
                 y: y_start + 1,
-                temporal_id: parent.temporal().clone(),
+                temporal_id: self.temporal().clone(),
             },
         ];
 
@@ -462,18 +462,7 @@ impl SingleId {
             }
         }
 
-        debug_assert_eq!(index, 7, "sibling set should contain exactly 7 items");
-        if index != 7 {
-            return None;
-        }
-
-        let [a, b, c, d, e, f, g] = siblings;
-        match (a, b, c, d, e, f, g) {
-            (Some(a), Some(b), Some(c), Some(d), Some(e), Some(f), Some(g)) => {
-                Some([a, b, c, d, e, f, g])
-            }
-            _ => None,
-        }
+        Some(siblings.map(|child| child.expect("sibling set should contain exactly 7 items")))
     }
 
     /// この [`SingleId`] の全ての親を、直近の親から順に列挙する。

--- a/src/spatial_id/single_id/test/mod.rs
+++ b/src/spatial_id/single_id/test/mod.rs
@@ -47,13 +47,6 @@ mod tests {
                 .iter()
                 .all(|s| s.spatial_parent_at_zoom(2).unwrap() == parent)
         );
-
-        let parent = id.spatial_parent_at_zoom(2).unwrap();
-        assert!(
-            siblings
-                .iter()
-                .all(|s| s.spatial_parent_at_zoom(2).unwrap() == parent)
-        );
     }
 
     #[test]

--- a/src/spatial_id/single_id/test/mod.rs
+++ b/src/spatial_id/single_id/test/mod.rs
@@ -33,6 +33,37 @@ mod tests {
     }
 
     #[test]
+    fn spatial_siblings_are_returned_for_non_root_ids() {
+        let id = SingleId::new(3, 3, 2, 7).unwrap();
+
+        let siblings = id.spatial_siblings().unwrap();
+
+        assert_eq!(siblings.len(), 7);
+        assert!(!siblings.contains(&id));
+
+        let parent = id.spatial_parent_at_zoom(2).unwrap();
+        assert!(
+            siblings
+                .iter()
+                .all(|s| s.spatial_parent_at_zoom(2).unwrap() == parent)
+        );
+
+        let parent = id.spatial_parent_at_zoom(2).unwrap();
+        assert!(
+            siblings
+                .iter()
+                .all(|s| s.spatial_parent_at_zoom(2).unwrap() == parent)
+        );
+    }
+
+    #[test]
+    fn spatial_siblings_is_none_at_root() {
+        let id = SingleId::new(0, 0, 0, 0).unwrap();
+
+        assert!(id.spatial_siblings().is_none());
+    }
+
+    #[test]
     fn spatial_parents_are_returned_from_nearest_to_root() {
         let id = SingleId::new(3, 3, 2, 7).unwrap();
 

--- a/src/spatial_id/temporal_id/disabled.rs
+++ b/src/spatial_id/temporal_id/disabled.rs
@@ -5,7 +5,7 @@ use crate::error::Error;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, PartialOrd, Ord, Default)]
 /// 時間IDの区間表現を表す型である（temporal_id feature無効時のスタブ）。
 ///
 /// `temporal_id` feature が無効な場合、[`TemporalId`] は常に全時間を表す

--- a/src/spatial_id/temporal_id/impls.rs
+++ b/src/spatial_id/temporal_id/impls.rs
@@ -10,6 +10,12 @@ impl Display for TemporalId {
     }
 }
 
+impl Default for TemporalId {
+    fn default() -> Self {
+        Self::WHOLE
+    }
+}
+
 /// 文字列表現から [`TemporalId`] を復元する。
 ///
 /// `"i/t"` 形式の文字列をパースして [`TemporalId`] を構築する。


### PR DESCRIPTION
# 用途
Kasaneのマージ可能なSingleIdを探すため

# 実装内容
- `pub fn spatial_siblings(&self) -> Option<[SingleId; 7]>`
- Docs
- テストを追加