### PR TITLE
Feat/add fractionalid

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,15 @@ pub enum GeometryError {
 
     ///半径が負であることを表す
     RadiusNegative { radius: f64 },
+
+    /// 高度方向インデックス `f` が、指定されたズームレベルに対して有効範囲外であることを示す。
+    FractionalFOutOfRange { z: u8, f: f64 },
+
+    /// X 方向インデックスが、指定されたズームレベルに対して有効範囲外であることを示す。
+    FractionalXOutOfRange { z: u8, x: f64 },
+
+    /// Y 方向インデックスが、指定されたズームレベルに対して有効範囲外であることを示す。
+    FractionalYOutOfRange { z: u8, y: f64 },
 }
 
 /// SpatialId 関連で発生するエラー。
@@ -52,7 +61,7 @@ pub enum SpatialIdError {
     /// Y 方向インデックスが、指定されたズームレベルに対して有効範囲外であることを示す。
     YOutOfRange { z: u8, y: u32 },
 
-    /// 時間方向が0-u64::MAXの有効範囲外であることを示す。
+    /// 時間方向が0-u64::MAX的有効範囲外であることを示す。
     /// 0=<i×t=<u64::MAXを満たす必要がある
     TOutOfRange { i: u64, t: u64 },
 
@@ -116,6 +125,27 @@ impl fmt::Display for GeometryError {
             }
             GeometryError::RadiusNegative { radius } => {
                 write!(f, "Radius need to be positive (radius = {}).", radius)
+            }
+            GeometryError::FractionalFOutOfRange { z, f: fv } => {
+                write!(
+                    f,
+                    "Fractional F coordinate '{}' is out of range for ZoomLevel '{}'",
+                    fv, z
+                )
+            }
+            GeometryError::FractionalXOutOfRange { z, x } => {
+                write!(
+                    f,
+                    "Fractional X coordinate '{}' is out of range for ZoomLevel '{}'",
+                    x, z
+                )
+            }
+            GeometryError::FractionalYOutOfRange { z, y } => {
+                write!(
+                    f,
+                    "Fractional Y coordinate '{}' is out of range for ZoomLevel '{}'",
+                    y, z
+                )
             }
         }
     }

--- a/src/geometry/point/fractionalid/impls.rs
+++ b/src/geometry/point/fractionalid/impls.rs
@@ -1,11 +1,51 @@
-use crate::{Coordinate, Ecef, FractionalId, spatial_id::helpers};
+use std::fmt;
 
-pub trait Point: Into<Ecef> {}
+use crate::{
+    Coordinate, Ecef, FractionalId, Point, SpatialIdError,
+    geometry::traits::CoverSingleIds,
+    spatial_id::{constants::MAX_ZOOM_LEVEL, helpers},
+};
+
+impl fmt::Debug for FractionalId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FractionalId")
+            .field("z", &self.z)
+            .field("f", &self.f)
+            .field("x", &self.x)
+            .field("y", &self.y)
+            .finish()
+    }
+}
+
 impl From<FractionalId> for Coordinate {
+    /// `FractionalId` から地理座標（`Coordinate`）への変換。
     fn from(value: FractionalId) -> Self {
         let alt = helpers::altitude(value.f, value.z);
         let lat = helpers::latitude(value.y, value.z);
         let lon = helpers::longitude(value.x, value.z);
         unsafe { Coordinate::new_unchecked(lat, lon, alt) }
+    }
+}
+
+impl From<FractionalId> for Ecef {
+    /// `FractionalId` から地心直交座標系（`Ecef`）への変換。
+    fn from(value: FractionalId) -> Self {
+        let coord: Coordinate = value.into();
+        coord.into()
+    }
+}
+
+impl Point for FractionalId {}
+
+impl CoverSingleIds for FractionalId {
+    fn cover_single_ids(
+        &self,
+        z: u8,
+    ) -> Result<impl Iterator<Item = crate::SingleId>, crate::Error> {
+        if z > MAX_ZOOM_LEVEL as u8 {
+            return Err(SpatialIdError::ZOutOfRange { z }.into());
+        }
+        let coord: Coordinate = (*self).into();
+        Ok(std::iter::once(coord.single_id(z)?))
     }
 }

--- a/src/geometry/point/fractionalid/impls.rs
+++ b/src/geometry/point/fractionalid/impls.rs
@@ -1,0 +1,11 @@
+use crate::{Coordinate, Ecef, FractionalId, spatial_id::helpers};
+
+pub trait Point: Into<Ecef> {}
+impl From<FractionalId> for Coordinate {
+    fn from(value: FractionalId) -> Self {
+        let alt = helpers::altitude(value.f, value.z);
+        let lat = helpers::latitude(value.y, value.z);
+        let lon = helpers::longitude(value.x, value.z);
+        unsafe { Coordinate::new_unchecked(lat, lon, alt) }
+    }
+}

--- a/src/geometry/point/fractionalid/mod.rs
+++ b/src/geometry/point/fractionalid/mod.rs
@@ -11,9 +11,6 @@ use crate::{
 /// 空間 ID (`SingleId`) が整数値のインデックスを持つのに対し、`FractionalId` は実数値（`f64`）の
 /// F、X、Y インデックスを保持することで、グリッド内のより詳細な位置や端点などを表現できます。
 ///
-/// この型は `PartialOrd` を実装していますが、これは主に `BTreeSet` や `BTreeMap`
-/// といった順序付きコレクションにおける格納および探索を目的としたものであり、空間的な位置関係における「大小」を意味するものではありません。
-///
 /// ```
 /// pub struct FractionalId {
 ///     z: u8,
@@ -65,21 +62,21 @@ impl FractionalId {
         let f_max = F_MAX[z as usize] as f64;
         let xy_max = XY_MAX[z as usize] as f64;
 
-        if f < f_min || f > f_max {
+        if f < f_min || f > f_max || !f.is_finite() {
             return Err(SpatialIdError::FOutOfRange {
                 f: libm::floor(f) as i32,
                 z,
             }
             .into());
         }
-        if x < 0.0 || x > xy_max {
+        if x < 0.0 || x > xy_max || !x.is_finite() {
             return Err(SpatialIdError::XOutOfRange {
                 x: if x < 0.0 { 0 } else { libm::floor(x) as u32 },
                 z,
             }
             .into());
         }
-        if y < 0.0 || y > xy_max {
+        if y < 0.0 || y > xy_max || !y.is_finite() {
             return Err(SpatialIdError::YOutOfRange {
                 y: if y < 0.0 { 0 } else { libm::floor(y) as u32 },
                 z,
@@ -158,7 +155,7 @@ impl FractionalId {
     pub fn set_f(&mut self, value: f64) -> Result<(), Error> {
         let min = F_MIN[self.z as usize] as f64;
         let max = F_MAX[self.z as usize] as f64;
-        if value < min || value > max {
+        if value < min || value > max || !value.is_finite() {
             return Err(SpatialIdError::FOutOfRange {
                 f: libm::floor(value) as i32,
                 z: self.z,
@@ -184,7 +181,7 @@ impl FractionalId {
     /// ```
     pub fn set_x(&mut self, value: f64) -> Result<(), Error> {
         let max = XY_MAX[self.z as usize] as f64;
-        if value < 0.0 || value > max {
+        if value < 0.0 || value > max || !value.is_finite() {
             return Err(SpatialIdError::XOutOfRange {
                 x: if value < 0.0 {
                     0
@@ -214,7 +211,7 @@ impl FractionalId {
     /// ```
     pub fn set_y(&mut self, value: f64) -> Result<(), Error> {
         let max = XY_MAX[self.z as usize] as f64;
-        if value < 0.0 || value > max {
+        if value < 0.0 || value > max || !value.is_finite() {
             return Err(SpatialIdError::YOutOfRange {
                 y: if value < 0.0 {
                     0

--- a/src/geometry/point/fractionalid/mod.rs
+++ b/src/geometry/point/fractionalid/mod.rs
@@ -2,7 +2,7 @@ pub mod impls;
 
 use crate::{
     SingleId,
-    error::{Error, SpatialIdError},
+    error::{Error, GeometryError, SpatialIdError},
     spatial_id::constants::{F_MAX, F_MIN, MAX_ZOOM_LEVEL, XY_MAX},
 };
 
@@ -63,25 +63,13 @@ impl FractionalId {
         let xy_max = XY_MAX[z as usize] as f64;
 
         if f < f_min || f > f_max || !f.is_finite() {
-            return Err(SpatialIdError::FOutOfRange {
-                f: libm::floor(f) as i32,
-                z,
-            }
-            .into());
+            return Err(GeometryError::FractionalFOutOfRange { f, z }.into());
         }
         if x < 0.0 || x > xy_max || !x.is_finite() {
-            return Err(SpatialIdError::XOutOfRange {
-                x: if x < 0.0 { 0 } else { libm::floor(x) as u32 },
-                z,
-            }
-            .into());
+            return Err(GeometryError::FractionalXOutOfRange { x, z }.into());
         }
         if y < 0.0 || y > xy_max || !y.is_finite() {
-            return Err(SpatialIdError::YOutOfRange {
-                y: if y < 0.0 { 0 } else { libm::floor(y) as u32 },
-                z,
-            }
-            .into());
+            return Err(GeometryError::FractionalYOutOfRange { y, z }.into());
         }
 
         Ok(FractionalId { z, f, x, y })
@@ -156,8 +144,8 @@ impl FractionalId {
         let min = F_MIN[self.z as usize] as f64;
         let max = F_MAX[self.z as usize] as f64;
         if value < min || value > max || !value.is_finite() {
-            return Err(SpatialIdError::FOutOfRange {
-                f: libm::floor(value) as i32,
+            return Err(GeometryError::FractionalFOutOfRange {
+                f: value,
                 z: self.z,
             }
             .into());
@@ -182,12 +170,8 @@ impl FractionalId {
     pub fn set_x(&mut self, value: f64) -> Result<(), Error> {
         let max = XY_MAX[self.z as usize] as f64;
         if value < 0.0 || value > max || !value.is_finite() {
-            return Err(SpatialIdError::XOutOfRange {
-                x: if value < 0.0 {
-                    0
-                } else {
-                    libm::floor(value) as u32
-                },
+            return Err(GeometryError::FractionalXOutOfRange {
+                x: value,
                 z: self.z,
             }
             .into());
@@ -212,12 +196,8 @@ impl FractionalId {
     pub fn set_y(&mut self, value: f64) -> Result<(), Error> {
         let max = XY_MAX[self.z as usize] as f64;
         if value < 0.0 || value > max || !value.is_finite() {
-            return Err(SpatialIdError::YOutOfRange {
-                y: if value < 0.0 {
-                    0
-                } else {
-                    libm::floor(value) as u32
-                },
+            return Err(GeometryError::FractionalYOutOfRange {
+                y: value,
                 z: self.z,
             }
             .into());
@@ -270,3 +250,6 @@ impl FractionalId {
         FractionalId { z, f, x, y }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/geometry/point/fractionalid/mod.rs
+++ b/src/geometry/point/fractionalid/mod.rs
@@ -1,8 +1,27 @@
 pub mod impls;
+
 use crate::{
+    SingleId,
     error::{Error, SpatialIdError},
     spatial_id::constants::{F_MAX, F_MIN, MAX_ZOOM_LEVEL, XY_MAX},
 };
+
+/// 実数値のインデックス（Z, F, X, Y）で表される空間 ID の座標型。
+///
+/// 空間 ID (`SingleId`) が整数値のインデックスを持つのに対し、`FractionalId` は実数値（`f64`）の
+/// F、X、Y インデックスを保持することで、グリッド内のより詳細な位置や端点などを表現できます。
+///
+/// この型は `PartialOrd` を実装していますが、これは主に `BTreeSet` や `BTreeMap`
+/// といった順序付きコレクションにおける格納および探索を目的としたものであり、空間的な位置関係における「大小」を意味するものではありません。
+///
+/// ```
+/// pub struct FractionalId {
+///     z: u8,
+///     f: f64,
+///     x: f64,
+///     y: f64,
+/// }
+/// ```
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
 pub struct FractionalId {
     z: u8,
@@ -10,7 +29,33 @@ pub struct FractionalId {
     x: f64,
     y: f64,
 }
+
 impl FractionalId {
+    /// 指定されたズームレベル、F、X、Y の各成分（実数値）から [`FractionalId`] を生成する。
+    ///
+    /// 各引数は、空間 ID 上で扱える座標インデックスとして有効な範囲に収まっている必要があります。
+    /// 範囲外の値が指定された場合、この関数は対応するエラーを返します。
+    ///
+    /// # 引数
+    /// * `z` - 空間 ID のズームレベル（0 〜 [`MAX_ZOOM_LEVEL`]）
+    /// * `f` - F インデックス（実数、ズームレベルごとの高度限界範囲内）
+    /// * `x` - X インデックス（実数、0.0 〜 `XY_MAX[z]`）
+    /// * `y` - Y インデックス（実数、0.0 〜 `XY_MAX[z]`）
+    ///
+    /// # 戻り値
+    /// * 有効な値が指定された場合は `Ok(FractionalId)` を返す。
+    /// * いずれかの値が範囲外の場合は、対応する `Error` を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// assert_eq!(fid.z(), 4);
+    /// assert_eq!(fid.f(), 5.5);
+    /// assert_eq!(fid.x(), 6.2);
+    /// assert_eq!(fid.y(), 7.8);
+    /// ```
     pub fn new(z: u8, f: f64, x: f64, y: f64) -> Result<Self, Error> {
         if z > MAX_ZOOM_LEVEL as u8 {
             return Err(SpatialIdError::ZOutOfRange { z }.into());
@@ -27,16 +72,16 @@ impl FractionalId {
             }
             .into());
         }
-        if x > xy_max {
+        if x < 0.0 || x > xy_max {
             return Err(SpatialIdError::XOutOfRange {
-                x: libm::floor(x) as u32,
+                x: if x < 0.0 { 0 } else { libm::floor(x) as u32 },
                 z,
             }
             .into());
         }
-        if y > xy_max {
+        if y < 0.0 || y > xy_max {
             return Err(SpatialIdError::YOutOfRange {
-                y: libm::floor(y) as u32,
+                y: if y < 0.0 { 0 } else { libm::floor(y) as u32 },
                 z,
             }
             .into());
@@ -44,14 +89,186 @@ impl FractionalId {
 
         Ok(FractionalId { z, f, x, y })
     }
-    /// * `z` が有効なズームレベル（0–[MAX_ZOOM_LEVEL]）であること
-    /// * `f` が与えられた `z` に応じて `F_MIN[z]..=F_MAX[z]` の範囲内であること
-    /// * `x` および `y` が `0..=XY_MAX[z]` の範囲内であること
+
+    /// ズームレベルを返す。
     ///
-    /// これらが保証されない場合、パニック・不正メモリアクセス・未定義動作を引き起こす可能性がある。
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// assert_eq!(fid.z(), 4);
+    /// ```
+    pub fn z(&self) -> u8 {
+        self.z
+    }
+
+    /// F インデックス（実数）を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// assert_eq!(fid.f(), 5.5);
+    /// ```
+    pub fn f(&self) -> f64 {
+        self.f
+    }
+
+    /// X インデックス（実数）を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// assert_eq!(fid.x(), 6.2);
+    /// ```
+    pub fn x(&self) -> f64 {
+        self.x
+    }
+
+    /// Y インデックス（実数）を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// assert_eq!(fid.y(), 7.8);
+    /// ```
+    pub fn y(&self) -> f64 {
+        self.y
+    }
+
+    /// F インデックスを更新する。
+    ///
+    /// 与えられた `value` が、現在のズームレベル `z` に対応する
+    /// `F_MIN[z]..=F_MAX[z]` の範囲内にあるかを検証し、範囲外の場合は [`Error`] を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let mut fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// fid.set_f(6.0).unwrap();
+    /// assert_eq!(fid.f(), 6.0);
+    /// ```
+    pub fn set_f(&mut self, value: f64) -> Result<(), Error> {
+        let min = F_MIN[self.z as usize] as f64;
+        let max = F_MAX[self.z as usize] as f64;
+        if value < min || value > max {
+            return Err(SpatialIdError::FOutOfRange {
+                f: libm::floor(value) as i32,
+                z: self.z,
+            }
+            .into());
+        }
+        self.f = value;
+        Ok(())
+    }
+
+    /// X インデックスを更新する。
+    ///
+    /// 与えられた `value` が、現在のズームレベル `z` に対応する
+    /// `0.0..=XY_MAX[z]` の範囲内にあるかを検証し、範囲外の場合は [`Error`] を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let mut fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// fid.set_x(8.0).unwrap();
+    /// assert_eq!(fid.x(), 8.0);
+    /// ```
+    pub fn set_x(&mut self, value: f64) -> Result<(), Error> {
+        let max = XY_MAX[self.z as usize] as f64;
+        if value < 0.0 || value > max {
+            return Err(SpatialIdError::XOutOfRange {
+                x: if value < 0.0 {
+                    0
+                } else {
+                    libm::floor(value) as u32
+                },
+                z: self.z,
+            }
+            .into());
+        }
+        self.x = value;
+        Ok(())
+    }
+
+    /// Y インデックスを更新する。
+    ///
+    /// 与えられた `value` が、現在のズームレベル `z` に対応する
+    /// `0.0..=XY_MAX[z]` の範囲内にあるかを検証し、範囲外の場合は [`Error`] を返す。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::FractionalId;
+    ///
+    /// let mut fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// fid.set_y(2.0).unwrap();
+    /// assert_eq!(fid.y(), 2.0);
+    /// ```
+    pub fn set_y(&mut self, value: f64) -> Result<(), Error> {
+        let max = XY_MAX[self.z as usize] as f64;
+        if value < 0.0 || value > max {
+            return Err(SpatialIdError::YOutOfRange {
+                y: if value < 0.0 {
+                    0
+                } else {
+                    libm::floor(value) as u32
+                },
+                z: self.z,
+            }
+            .into());
+        }
+        self.y = value;
+        Ok(())
+    }
+
+    /// この `FractionalId` が属する、整数値インデックスの [`SingleId`] を返す。
+    ///
+    /// 内部的には各実数値インデックス（F, X, Y）の床関数（`floor`）を取ることで
+    /// 対応する [`SingleId`] を計算します。
+    ///
+    /// # Examples
+    /// ```
+    /// # use kasane_logic::{FractionalId, SingleId};
+    ///
+    /// let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    /// let sid = fid.single_id();
+    /// assert_eq!(sid.z(), 4);
+    /// assert_eq!(sid.f(), 5);
+    /// assert_eq!(sid.x(), 6);
+    /// assert_eq!(sid.y(), 7);
+    /// ```
+    pub fn single_id(&self) -> SingleId {
+        unsafe {
+            SingleId::new_unchecked(
+                self.z,
+                libm::floor(self.f) as i32,
+                libm::floor(self.x) as u32,
+                libm::floor(self.y) as u32,
+            )
+        }
+    }
+
+    /// 値の妥当性検証を行わずに [`FractionalId`] を生成する。
+    ///
+    /// この関数はズームレベルや各実数インデックスに対する範囲チェックを一切行いません。
+    /// 呼び出し側は、渡す値が空間 ID の有効な範囲に収まっていることを保証する責任を負います。
     ///
     /// # Safety
+    /// この関数は `unsafe` です。
     ///
+    /// 以下の制約が保証されない場合、パニック、不正メモリアクセス、未定義動作、
+    /// または論理的な不整合を引き起こす可能性があります：
+    /// * `z` が有効なズームレベル（0 〜 [`MAX_ZOOM_LEVEL`]）であること
+    /// * `f` が `F_MIN[z]..=F_MAX[z]` の範囲内であること
+    /// * `x` および `y` が `0.0..=XY_MAX[z]` の範囲内であること
     pub unsafe fn new_unchecked(z: u8, f: f64, x: f64, y: f64) -> Self {
         FractionalId { z, f, x, y }
     }

--- a/src/geometry/point/fractionalid/mod.rs
+++ b/src/geometry/point/fractionalid/mod.rs
@@ -1,0 +1,58 @@
+pub mod impls;
+use crate::{
+    error::{Error, SpatialIdError},
+    spatial_id::constants::{F_MAX, F_MIN, MAX_ZOOM_LEVEL, XY_MAX},
+};
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub struct FractionalId {
+    z: u8,
+    f: f64,
+    x: f64,
+    y: f64,
+}
+impl FractionalId {
+    pub fn new(z: u8, f: f64, x: f64, y: f64) -> Result<Self, Error> {
+        if z > MAX_ZOOM_LEVEL as u8 {
+            return Err(SpatialIdError::ZOutOfRange { z }.into());
+        }
+
+        let f_min = F_MIN[z as usize] as f64;
+        let f_max = F_MAX[z as usize] as f64;
+        let xy_max = XY_MAX[z as usize] as f64;
+
+        if f < f_min || f > f_max {
+            return Err(SpatialIdError::FOutOfRange {
+                f: libm::floor(f) as i32,
+                z,
+            }
+            .into());
+        }
+        if x > xy_max {
+            return Err(SpatialIdError::XOutOfRange {
+                x: libm::floor(x) as u32,
+                z,
+            }
+            .into());
+        }
+        if y > xy_max {
+            return Err(SpatialIdError::YOutOfRange {
+                y: libm::floor(y) as u32,
+                z,
+            }
+            .into());
+        }
+
+        Ok(FractionalId { z, f, x, y })
+    }
+    /// * `z` が有効なズームレベル（0–[MAX_ZOOM_LEVEL]）であること
+    /// * `f` が与えられた `z` に応じて `F_MIN[z]..=F_MAX[z]` の範囲内であること
+    /// * `x` および `y` が `0..=XY_MAX[z]` の範囲内であること
+    ///
+    /// これらが保証されない場合、パニック・不正メモリアクセス・未定義動作を引き起こす可能性がある。
+    ///
+    /// # Safety
+    ///
+    pub unsafe fn new_unchecked(z: u8, f: f64, x: f64, y: f64) -> Self {
+        FractionalId { z, f, x, y }
+    }
+}

--- a/src/geometry/point/fractionalid/tests.rs
+++ b/src/geometry/point/fractionalid/tests.rs
@@ -1,0 +1,40 @@
+use crate::{Coordinate, Ecef, FractionalId, geometry::traits::CoverSingleIds};
+
+#[test]
+fn test_fractional_id_to_single_id() {
+    let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    let sid = fid.single_id();
+    assert_eq!(sid.z(), 4);
+    assert_eq!(sid.f(), 5);
+    assert_eq!(sid.x(), 6);
+    assert_eq!(sid.y(), 7);
+}
+
+#[test]
+fn test_fractional_id_to_coordinate() {
+    let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    let coord: Coordinate = fid.into();
+    assert!(coord.latitude() >= -90.0 && coord.latitude() <= 90.0);
+    assert!(coord.longitude() >= -180.0 && coord.longitude() <= 180.0);
+}
+
+#[test]
+fn test_fractional_id_to_ecef() {
+    let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+    let ecef: Ecef = fid.into();
+    let origin = Ecef::new(0.0, 0.0, 0.0);
+    let r = ecef.distance(&origin);
+    assert!(r >= 0.0);
+}
+
+#[test]
+fn test_cover_single_ids() {
+    let fid = FractionalId::new(4, 5.5, 6.2, 7.8).unwrap();
+
+    let mut iter = fid.cover_single_ids(4).unwrap();
+    let sid = iter.next().unwrap();
+
+    assert_eq!(sid.z(), 4);
+
+    assert!(iter.next().is_none());
+}

--- a/src/geometry/point/mod.rs
+++ b/src/geometry/point/mod.rs
@@ -1,3 +1,4 @@
 pub mod coordinate;
 pub mod ecef;
+pub mod fractionalid;
 pub mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,9 @@ pub mod spatial_id;
 #[doc(inline)]
 pub use error::Error;
 #[doc(inline)]
-pub use geometry::point::{coordinate::Coordinate, ecef::Ecef, traits::Point};
+pub use geometry::point::{
+    coordinate::Coordinate, ecef::Ecef, fractionalid::FractionalId, traits::Point,
+};
 
 #[doc(inline)]
 pub use error::{GeometryError, SpatialIdError};


### PR DESCRIPTION
# FractionalId型を定義
- mod.rsでは、SingleIdのmodを参考に最低限のモジュールを実装
- impl.rsでは、主にEcefやCoordinateとの変換を実装
問題なくmergeされれば、Vec3の実装に移ります。