### PR TITLE
vscodeの軽量化設定を導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-	"rust-analyzer.cargo.features": ["random"],
+	"rust-analyzer.cargo.targetDir": true,
+	"rust-analyzer.procMacro.enable": false,
+	"rust-analyzer.cargo.features": [
+		"random"
+	],
 	"rust-analyzer.check.command": "clippy",
 	"chat.tools.terminal.autoApprove": {
 		"cargo test *": true,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "similar"

--- a/src/geometry/shape/line/impls.rs
+++ b/src/geometry/shape/line/impls.rs
@@ -28,7 +28,7 @@ impl CoverSingleIds for Line {
             + (v1.x() as i32 - v2.x() as i32).abs()
             + (v1.y() as i32 - v2.y() as i32).abs()) as f64;
         let devide_num = 5 + libm::floor(diff / 120.0 + distance / 2000.0) as u16;
-        let mut coordinates = Vec::new();
+        let mut coordinates = Vec::with_capacity(devide_num as usize + 1);
         for i in 0..=devide_num {
             let t = i as f64 / devide_num as f64;
             let x = ecef_a.x() * (1.0 - t) + ecef_b.x() * t;
@@ -37,7 +37,8 @@ impl CoverSingleIds for Line {
             let coo: Coordinate = Ecef::new(x, y, z_pos).try_into()?;
             coordinates.push(coo);
         }
-        let mut voxels: Vec<SingleId> = Vec::new();
+        let estimated_capacity = (diff as usize) + (devide_num as usize) * 2 + 10;
+        let mut voxels: Vec<SingleId> = Vec::with_capacity(estimated_capacity);
         for pair in coordinates.windows(2) {
             let start = pair[0];
             let end = pair[1];


### PR DESCRIPTION
```
"rust-analyzer.cargo.targetDir": true,
"rust-analyzer.procMacro.enable": false,
```
を導入して、エディタを軽量に動くようにした。