### PR TITLE
vscodeの軽量化設定を導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-	"rust-analyzer.cargo.features": ["random"],
+	"rust-analyzer.cargo.targetDir": true,
+	"rust-analyzer.procMacro.enable": false,
+	"rust-analyzer.cargo.features": [
+		"random"
+	],
 	"rust-analyzer.check.command": "clippy",
 	"chat.tools.terminal.autoApprove": {
 		"cargo test *": true,


### PR DESCRIPTION
```
"rust-analyzer.cargo.targetDir": true,
"rust-analyzer.procMacro.enable": false,
```
を導入して、エディタを軽量に動くようにした。