### PR TITLE
自動分割機能の追加

### DIFF
--- a/src/geometry/shape/cylinder/mod.rs
+++ b/src/geometry/shape/cylinder/mod.rs
@@ -5,7 +5,7 @@ pub mod impls;
 mod tests;
 use core::f64::consts::PI;
 
-use crate::{Coordinate, Ecef, Error, GeometryError, Polygon, Solid, Vec3, Vec3Ecef};
+use crate::{Coordinate, Ecef, Error, GeometryError, Polygon, Solid, Vec3, Vec3Ecef, ZoomLevel};
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// 3次元空間における円柱を表す型。
 ///
@@ -31,18 +31,70 @@ impl Cylinder {
 
     /// [Cylinder]を近似した[Solid]を作成する関数
     pub fn rough_solid(&self) -> Solid {
-        let polygons = self.rough_surfaces().collect();
+        let polygons = self.rough_surfaces_without_z().collect();
         Solid::new(polygons, 1e-10).unwrap()
     }
 
-    /// [Cylinder]を近似した立体の表面を[Polygon]として返す関数
-    pub fn rough_surfaces(&self) -> impl Iterator<Item = Polygon> {
+    /// [Cylinder]を近似した立体の表面を、ズームレベルを指定せずに[Polygon]として返す関数
+    pub fn rough_surfaces_without_z(&self) -> impl Iterator<Item = Polygon> {
         let vecs: [Vec3Ecef; 2] = [self.start.into(), self.end.into()];
         let vec_n = vecs[1] - vecs[0];
         let basis = vec_n
             .create_orthonormal_basis()
             .map(|v| v.scale(self.radius_m));
-        let divide_num = 100_u32;
+        let divide_num = 57_u32;
+        let vertices: Vec<_> = (0..divide_num)
+            .map(|i| {
+                let theta = 2.0 * PI * i as f64 / divide_num as f64;
+                let v = basis[0].scale(libm::cos(theta)) + basis[1].scale(libm::sin(theta));
+                [vecs[0] + v, vecs[1] + v]
+            })
+            .collect();
+
+        let to_coord = |v: Vec3Ecef| Coordinate::try_from(Ecef::from(v)).unwrap();
+
+        // 側面の頂点リスト（イテレータ）を作成
+        let side_surfaces = (0..divide_num).map(|i| {
+            let next_i = (i + 1) % divide_num;
+            let v_curr = vertices[i as usize];
+            let v_next = vertices[next_i as usize];
+
+            Polygon::new(
+                vec![
+                    to_coord(v_curr[0]),
+                    to_coord(v_next[0]),
+                    to_coord(v_next[1]),
+                    to_coord(v_curr[1]),
+                ],
+                1e-10,
+            )
+        });
+
+        // 側面を全て集める
+        let mut raw_surfaces: Vec<Polygon> = side_surfaces.collect();
+
+        // 底面
+        raw_surfaces.push(Polygon::new(
+            vertices.iter().rev().map(|v| to_coord(v[0])).collect(),
+            1e-10,
+        ));
+        // 上面
+        raw_surfaces.push(Polygon::new(
+            vertices.iter().map(|v| to_coord(v[1])).collect(),
+            1e-10,
+        ));
+
+        raw_surfaces.into_iter()
+    }
+    /// [Cylinder]を近似した立体の表面を、ズームレベルを指定してに[Polygon]として返す関数
+    pub fn rough_surfaces_with_z(&self, z: ZoomLevel) -> impl Iterator<Item = Polygon> {
+        let vecs: [Vec3Ecef; 2] = [self.start.into(), self.end.into()];
+        let vec_n = vecs[1] - vecs[0];
+        let basis = vec_n
+            .create_orthonormal_basis()
+            .map(|v| v.scale(self.radius_m));
+        let divide_num =
+            (57_u32).max((self.radius_m * PI / (2_f64.powi(25 - u8::from(z) as i32) * 3.0)) as u32);
         let vertices: Vec<_> = (0..divide_num)
             .map(|i| {
                 let theta = 2.0 * PI * i as f64 / divide_num as f64;

--- a/src/geometry/shape/cylinder/mod.rs
+++ b/src/geometry/shape/cylinder/mod.rs
@@ -93,8 +93,8 @@ impl Cylinder {
         let basis = vec_n
             .create_orthonormal_basis()
             .map(|v| v.scale(self.radius_m));
-        let divide_num =
-            (57_u32).max((self.radius_m * PI / (2_f64.powi(25 - u8::from(z) as i32) * 3.0)) as u32);
+        let divide_num = (57_u32)
+            .max((self.radius_m * PI / (libm::pow(2.0, (25 - u8::from(z)) as f64) * 3.0)) as u32);
         let vertices: Vec<_> = (0..divide_num)
             .map(|i| {
                 let theta = 2.0 * PI * i as f64 / divide_num as f64;

--- a/src/geometry/shape/cylinder/mod.rs
+++ b/src/geometry/shape/cylinder/mod.rs
@@ -93,8 +93,9 @@ impl Cylinder {
         let basis = vec_n
             .create_orthonormal_basis()
             .map(|v| v.scale(self.radius_m));
-        let divide_num = (57_u32)
-            .max((self.radius_m * PI / (libm::pow(2.0, (25 - u8::from(z)) as f64) * 3.0)) as u32);
+        let divide_num = (57_u32).max(
+            (self.radius_m * PI / (libm::pow(2.0, (25 - u8::from(z) as i16) as f64) * 3.0)) as u32,
+        );
         let vertices: Vec<_> = (0..divide_num)
             .map(|i| {
                 let theta = 2.0 * PI * i as f64 / divide_num as f64;

--- a/src/geometry/shape/cylinder/tests.rs
+++ b/src/geometry/shape/cylinder/tests.rs
@@ -54,3 +54,21 @@ mod cover_single_ids {
         insta::assert_debug_snapshot!(sorted_ids(&cylinder, 18));
     }
 }
+
+mod rough_surfaces_with_z {
+    use super::*;
+    use crate::ZoomLevel;
+
+    #[test]
+    fn test_zoom_level_over_25_panic() {
+        let start = Coordinate::new(35.681, 139.766, 0.0).unwrap();
+        let end = Coordinate::new(35.681, 139.766, 32.0).unwrap();
+        let cylinder = Cylinder::new(start, end, 5.0).unwrap();
+
+        // ZoomLevel::MAX (30) 以内だが、25を超える値
+        let z = ZoomLevel::new(26).unwrap();
+
+        // 現在の実装では、内部で (25 - u8::from(z)) がアンダーフローし、パニックする
+        let _ = cylinder.rough_surfaces_with_z(z);
+    }
+}


### PR DESCRIPTION
AIの指摘や、アルゴリズムmtgでの協議を経てさらに修正を施した。今までの修正もまとめて書く。
・ズームレベルに応じた自動分割機能の追加。値の根拠F方向の大きさで計算することで煩雑化を回避。
・with_zとwithout_zで、ズームレベルを参照するか否かを選択できる。withoutという名前は良い。withが前提にあることをつかうものに意識させられる。
・ユースケース的に計算量爆発は起きないと踏んで上限は導入しない

⇩前のPR
https://github.com/AirBee-Project/Kasane-Logic/pull/159