### PR TITLE
Revert "Grid経路を高速化"

### DIFF
--- a/src/spatial_id/collection/query/grid/mod.rs
+++ b/src/spatial_id/collection/query/grid/mod.rs
@@ -82,7 +82,7 @@ const MAX_BYTES: u64 = 512 * 1024 * 1024;
 ///
 /// すべて全時間（`t_zoomlevel == 0`）で、空間 3 軸のズームは `z` に揃っている。
 /// 位置は重複しない（各演算がこの不変条件を保つ）。
-pub struct UniformGrid<V: SafeValue> {
+pub(crate) struct UniformGrid<V: SafeValue> {
     z: ZoomLevel,
     entries: Vec<SingleEntry<V>>,
     order: Option<Order>,
@@ -196,33 +196,6 @@ impl<V: SafeValue> UniformGrid<V> {
         Ok(Some(lo..=hi))
     }
 
-    /// 対象軸のインデックスを `>> Δz` してマージするズームアウト。
-    pub(crate) fn zoom_out<
-        P: crate::spatial_id::collection::query::merge_policy::MergePolicy<V>,
-    >(
-        &mut self,
-        target_z: ZoomLevel,
-        token: &CancellationToken,
-    ) -> Result<(), Error> {
-        if target_z.get() >= self.z.get() {
-            return Ok(());
-        }
-        let dz = self.z.get() - target_z.get();
-
-        let mut ctr = 0u32;
-        for e in &mut self.entries {
-            token.check_amortized(&mut ctr)?;
-            e.0 >>= dz;
-            e.1 >>= dz;
-            e.2 >>= dz;
-        }
-
-        self.z = target_z;
-        self.order = None;
-        self.sort_morton(&|a: &V, b: &V| P::resolve(a.clone(), b.clone()));
-        Ok(())
-    }
-
     /// 軸方向の平行移動。
     ///
     /// F / Y で範囲外へ出るものがあれば、`FlexId::shift_f` / `shift_y` が `Err` を返して
@@ -233,12 +206,9 @@ impl<V: SafeValue> UniformGrid<V> {
         op_z: ZoomLevel,
         delta: i32,
         token: &CancellationToken,
-    ) -> Result<Applied, Error> {
-        if self.z.get() < op_z.get() {
-            return Ok(Applied::Unsupported);
-        }
+    ) -> Result<(), Error> {
         if delta == 0 {
-            return Ok(Applied::Done);
+            return Ok(());
         }
         // グリッドのズームは op_z 以上（呼び出し側が保証）。
         let d = delta as i64 * (1i64 << (self.z.get() - op_z.get()));
@@ -252,7 +222,7 @@ impl<V: SafeValue> UniformGrid<V> {
             }
             // 巡回で並びが崩れる（位置の一意性は保たれる）。
             self.order = None;
-            return Ok(Applied::Done);
+            return Ok(());
         }
 
         // 移動先が軸の範囲を外れる葉があれば、木経路と同じく演算全体をエラーにする。
@@ -295,7 +265,7 @@ impl<V: SafeValue> UniformGrid<V> {
         if self.order == Some(Order::Morton) {
             self.order = None;
         }
-        Ok(Applied::Done)
+        Ok(())
     }
 
     /// 線形減衰つきの伝播。
@@ -318,9 +288,6 @@ impl<V: SafeValue> UniformGrid<V> {
         P: crate::spatial_id::collection::query::merge_policy::MergePolicy<V>,
         A: GridAttenuator<V> + MaybeSendSync,
     {
-        if self.z.get() < op_z.get() {
-            return Ok(Applied::Unsupported);
-        }
         self.sort_lanes(axis);
 
         let span = 1i64 << self.z.get();
@@ -395,7 +362,7 @@ impl<V: SafeValue> UniformGrid<V> {
 }
 
 /// グリッド経路で実行しきれたか。
-pub enum Applied {
+pub(crate) enum Applied {
     Done,
     /// グリッドでは元の意味を再現できないので木経路に任せる。
     ///
@@ -524,7 +491,7 @@ where
                 .map(|(acc, _, _)| acc)
                 .collect();
 
-            let mut out = Vec::with_capacity(estimated_output(entries.len(), params));
+            let mut out = Vec::new();
             for chunk in chunks {
                 out.extend(chunk?);
             }

--- a/src/spatial_id/collection/query/grid/test.rs
+++ b/src/spatial_id/collection/query/grid/test.rs
@@ -264,7 +264,6 @@ mod property {
         FalloffX(u32, u8),
         FalloffY(u32, u8),
         FalloffF(u32, u8),
-        ZoomOut(u8),
     }
 
     /// 可換なポリシー（グリッド経路が対象とするもの）だけを選ぶ。
@@ -288,12 +287,6 @@ mod property {
             Op::FalloffX(r, p) => falloff!(FalloffX, r, p),
             Op::FalloffY(r, p) => falloff!(FalloffY, r, p),
             Op::FalloffF(r, p) => falloff!(FalloffF, r, p),
-            Op::ZoomOut(dz) => Box::new(
-                crate::spatial_id::collection::query::ops::unary::zoom_out::zoom_out::ZoomOut::<
-                    u32,
-                    Max,
-                >::new(crate::ZoomLevel::new(z.saturating_sub(dz)).unwrap()),
-            ),
         }
     }
 
@@ -305,7 +298,6 @@ mod property {
             (0..=3u32, 0..=2u8).prop_map(|(r, p)| Op::FalloffX(r, p)),
             (0..=3u32, 0..=2u8).prop_map(|(r, p)| Op::FalloffY(r, p)),
             (0..=3u32, 0..=2u8).prop_map(|(r, p)| Op::FalloffF(r, p)),
-            (0..=2u8).prop_map(Op::ZoomOut),
         ]
     }
 

--- a/src/spatial_id/collection/query/ops/unary/shift/shift_f.rs
+++ b/src/spatial_id/collection/query/ops/unary/shift/shift_f.rs
@@ -73,5 +73,6 @@ impl<V: SafeValue + 'static> UnaryOperator<V> for ShiftF {
         token: &crate::CancellationToken,
     ) -> Result<crate::spatial_id::collection::query::grid::Applied, crate::Error> {
         grid.shift(GridAxis::F, self.z, self.f, token)
+            .map(|_| crate::spatial_id::collection::query::grid::Applied::Done)
     }
 }

--- a/src/spatial_id/collection/query/ops/unary/shift/shift_x.rs
+++ b/src/spatial_id/collection/query/ops/unary/shift/shift_x.rs
@@ -71,5 +71,6 @@ impl<V: SafeValue + 'static> UnaryOperator<V> for ShiftX {
         token: &crate::CancellationToken,
     ) -> Result<crate::spatial_id::collection::query::grid::Applied, crate::Error> {
         grid.shift(GridAxis::X, self.z, self.x, token)
+            .map(|_| crate::spatial_id::collection::query::grid::Applied::Done)
     }
 }

--- a/src/spatial_id/collection/query/ops/unary/shift/shift_y.rs
+++ b/src/spatial_id/collection/query/ops/unary/shift/shift_y.rs
@@ -71,5 +71,6 @@ impl<V: SafeValue + 'static> UnaryOperator<V> for ShiftY {
         token: &crate::CancellationToken,
     ) -> Result<crate::spatial_id::collection::query::grid::Applied, crate::Error> {
         grid.shift(GridAxis::Y, self.z, self.y, token)
+            .map(|_| crate::spatial_id::collection::query::grid::Applied::Done)
     }
 }

--- a/src/spatial_id/collection/query/ops/unary/zoom_out/zoom_out.rs
+++ b/src/spatial_id/collection/query/ops/unary/zoom_out/zoom_out.rs
@@ -139,23 +139,6 @@ where
         CommutativityInfo::None
     }
 
-    fn grid_zoom(&self) -> Option<crate::ZoomLevel> {
-        Some(self.target_z)
-    }
-
-    #[allow(private_interfaces)]
-    fn apply_to_grid(
-        &self,
-        grid: &mut crate::spatial_id::collection::query::grid::UniformGrid<V>,
-        token: &crate::CancellationToken,
-    ) -> Result<crate::spatial_id::collection::query::grid::Applied, Error> {
-        if !P::IS_COMMUTATIVE {
-            return Ok(crate::spatial_id::collection::query::grid::Applied::Unsupported);
-        }
-        grid.zoom_out::<P>(self.target_z, token)?;
-        Ok(crate::spatial_id::collection::query::grid::Applied::Done)
-    }
-
     fn fmt_op(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "zoom_out(z={})", self.target_z.get())
     }


### PR DESCRIPTION
Reverts AirBee-Project/Kasane-Logic#256

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AirBee-Project/codesmith/Kasane-Logic/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789796656&installation_model_id=427793&pr_number=258&repository=AirBee-Project%2FKasane-Logic&return_to=https%3A%2F%2Fgithub.com%2FAirBee-Project%2FKasane-Logic%2Fpull%2F258&signature=1bfd64a5ee61b8de553379532b93a39639dc794f80a59b9a33738aa8d2239c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->